### PR TITLE
Support deploying Prometheus Swarm service

### DIFF
--- a/ansible/deploy_prometheus_swarm_monitoring.yml
+++ b/ansible/deploy_prometheus_swarm_monitoring.yml
@@ -1,0 +1,10 @@
+#
+# Copyright StackHPC, 2018
+#
+---
+- name: Deploy Prometheus Swarm monitoring service
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+  - role: prometheus_swarm_service

--- a/ansible/roles/prometheus_swarm_service/README.md
+++ b/ansible/roles/prometheus_swarm_service/README.md
@@ -1,0 +1,19 @@
+Prometheus Swarm monitoring service
+===================================
+
+This role assumes the following environment variables have been set
+in order to interact with the target Swarm Docker API.
+
+* `DOCKER_HOST`
+* `DOCKER_CERT_PATH`
+* `DOCKER_TLS_VERIFY`
+
+A script to set these can be generated from the OpenStack CLI:
+
+`mkdir -p ~/swarm-creds && $(openstack coe cluster config <cluster name> --dir ~/swarm-creds --force | tee ~/swarm-creds/env.sh)`
+
+This role currently makes no attempt to configure the Prometheus server to scrape
+the Swarm cluster nodes. If the Swarm cluster is re-deployed, the server configuration
+will need to be updated.
+
+The role requires Docker Engine 18.02.0+. This includes the client running on the localhost.

--- a/ansible/roles/prometheus_swarm_service/files/prometheus_swarm_service.yml
+++ b/ansible/roles/prometheus_swarm_service/files/prometheus_swarm_service.yml
@@ -1,0 +1,31 @@
+---
+version: "3.6"
+
+networks:
+  hostnet:
+    external: true
+    name: host
+
+services:
+  prom-node-exporter:
+    image: prom/node-exporter
+    networks:
+      hostnet: {}
+    logging:
+      driver: fluentd
+    deploy:
+      mode: global
+  cadvisor:
+    image: google/cadvisor
+    networks:
+      hostnet: {}
+    logging:
+      driver: fluentd
+    deploy:
+      mode: global
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/rootfs:ro
+      - /var/run:/var/run
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro

--- a/ansible/roles/prometheus_swarm_service/tasks/main.yml
+++ b/ansible/roles/prometheus_swarm_service/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Deploy Prometheus Swarm service
+   # At the time of writing the docker_compose module doesn't support compose v3
+   # and we want compose v3 for the global deploy mode.
+  command: "docker stack deploy --compose-file {{ role_path }}/files/prometheus_swarm_service.yml prometheus-monitoring-stack"
+  environment:
+    DOCKER_HOST: "{{ lookup('env','DOCKER_HOST') }}"
+    DOCKER_CERT_PATH: "{{ lookup('env','DOCKER_CERT_PATH') }}"
+    DOCKER_TLS_VERIFY: "{{ lookup('env','DOCKER_TLS_VERIFY') }}"


### PR DESCRIPTION
This deploys cAdvisor and Prometheus node exporter
on all nodes in the Swarm cluster.

It makes no attempt to configure the Prometheus server.