### PR TITLE
Fixup monitoring playbook

### DIFF
--- a/ansible/group_vars/all/alaska
+++ b/ansible/group_vars/all/alaska
@@ -6,8 +6,8 @@ alaska_cloud: alaska
 alaska_homedir: /alaska
 alaska_softiron: 10.4.99.101
 
-# OpenStack fully qualified project name (used for Grafana with domain support)
-project_name: p3@default
+# OpenStack p3 project name
+project_name: p3
 
 # Virtual IP address of the controller node
 controller_vip: 10.60.253.1
@@ -27,7 +27,7 @@ monasca_swarm_service_log_api_uri: http://{{ controller_vip }}:5607
 monasca_swarm_service_keystone_uri: http://{{ controller_vip }}:5000/v3
 monasca_swarm_service_username: "{{ monasca_agent_p3_username }}"
 monasca_swarm_service_password: "{{ monasca_agent_p3_password }}"
-monasca_swarm_service_project_name: p3
+monasca_swarm_service_project_name: "{{ project_name }}"
 
 # Local Grafana admin account for configuring Grafana
 grafana_admin_username: grafana-admin

--- a/ansible/monitoring.yml
+++ b/ansible/monitoring.yml
@@ -13,7 +13,7 @@
     monasca_agent_user: "{{ monasca_agent_p3_username }}"
     monasca_agent_password: "{{ monasca_agent_p3_password }}"
     monasca_agent_project: "{{ project_name }}"
-    monasca_agent_version: 2.2.0
+    monasca_agent_branch: stable/pike
     monasca_endpoint_type: public
     monasca_project_domain_name: Default
     monasca_user_domain_name: Default
@@ -29,7 +29,8 @@
         username: "{{ monasca_agent_p3_username }}"
         password: "{{ monasca_agent_p3_password }}"
     monasca_rsyslog_venv: "/opt/monasca-rsyslog"
-    monasca_rsyslog_api_endpoint: "http://{{ alaska_monitoring_server }}:5607/v3.0"
+    # FIXME: The plugin should get this from the Keystone catalogue
+    monasca_rsyslog_api_endpoint: "http://{{ controller_vip }}:5607/v3.0"
 
 - name: Configure dashboards
   hosts: cluster_login


### PR DESCRIPTION
* @domain syntax no longer seems to work for auth
* Use VIP for logging now that we have HAProxy entry for Log API
* Use version of monasca-agent with fix for new Tornado lib