### PR TITLE
Slurm config syntax fix

### DIFF
--- a/ansible/roles/openhpc_runtime/handlers/main.yml
+++ b/ansible/roles/openhpc_runtime/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Restart SLURM service
   service:
     name: "{{slurm_service}}"
-    state: restarted
+    state: reloaded
   when: slurm_service_enabled | bool

--- a/ansible/roles/openhpc_runtime/templates/slurm.conf.j2
+++ b/ansible/roles/openhpc_runtime/templates/slurm.conf.j2
@@ -115,8 +115,9 @@ NodeName={{group.cluster_name|default(cluster_name)}}-{{group.name}}-[0-{{group.
 {% set first_host_hv = hostvars[group_hosts | first] %}
     Sockets={{first_host_hv['ansible_processor_count']}} \
     CoresPerSocket={{first_host_hv['ansible_processor_cores']}} \
-    ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}} State=UNKNOWN
+    ThreadsPerCore={{first_host_hv['ansible_processor_threads_per_core']}} \
 {% endif %}
+    State=UNKNOWN
 {% endfor %}
 {% endfor %}
 {% for part in slurm_partitions %}


### PR DESCRIPTION
When facts are not available for CPU cores etc, the config generated was mangled with an escaped newline.  This can happen when limiting to a subset of nodes (this isn't a good idea for
exactly this reason).  At least generate a well-formed config file in these circumstances.