### PR TITLE
Improve scalability of /etc/hosts generation

### DIFF
--- a/ansible/roles/cluster_setup/tasks/hosts.yml
+++ b/ansible/roles/cluster_setup/tasks/hosts.yml
@@ -1,13 +1,17 @@
 ---
+- name: Generate /etc/hosts file content
+  set_fact:
+    etc_hosts_content: |
+      {% for host in ansible_play_hosts %}{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ host }}.novalocal {{ host }}
+      {% endfor %}
+  run_once: true
+
 - name: Create entries in /etc/hosts for all nodes
-  lineinfile:
+  blockinfile:
     path: /etc/hosts
-    line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }} {{ item }}.novalocal {{ item }}"
-    regexp: "^.* {{ item }}$"
     create: no
     state: present
-  with_items:
-    - "{{ ansible_play_hosts }}"
+    block: "{{ hostvars[ansible_play_hosts[0]].etc_hosts_content }}"
 
 - name: Update hostname
   hostname:


### PR DESCRIPTION
The previous algorithm was O(n^2) as it had to access (and to some extent
evaluate) the hostvars of every host for every host. We now generate the file
contents once, and reference the contents. This should be O(n).