### PR TITLE
Reload mlx5_ib module and set selinux to permissive mode

### DIFF
--- a/ansible/configure-ib.yml
+++ b/ansible/configure-ib.yml
@@ -1,4 +1,6 @@
 - hosts: cluster
+  vars:
+    ib_ipaddr: "{{ hostvars[inventory_hostname]['server_networks'][lln_name][0] | default(omit) }}"
   roles:
   - configure_ib
   become: yes

--- a/ansible/roles/configure_ib/handlers/main.yml
+++ b/ansible/roles/configure_ib/handlers/main.yml
@@ -6,19 +6,23 @@
     state: restarted
   become: True
 
+- name: Unload kernel modules
+  modprobe:
+    name: "{{ item }}"
+    state: absent
+  with_items: "{{ ib_modules }}"
+  become: yes
+  notify: Reset interface
+
+- name: Load kernel modules
+  modprobe:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ ib_modules }}"
+  become: yes
+  notify: Reset interface
+
 - name: Reset interface
   shell: ifdown ib0; ifup ib0
-  become: yes
-
-- name: Remove mlx5_ib module
-  modprobe:
-    name: mlx5_ib
-    state: absent
-  become: yes
-
-- name: Probe mlx5_ib module
-  modprobe:
-    name: mlx5_ib
-    state: present 
   become: yes
 ...

--- a/ansible/roles/configure_ib/handlers/main.yml
+++ b/ansible/roles/configure_ib/handlers/main.yml
@@ -9,4 +9,16 @@
 - name: Reset interface
   shell: ifdown ib0; ifup ib0
   become: yes
+
+- name: Remove mlx5_ib module
+  modprobe:
+    name: mlx5_ib
+    state: absent
+  become: yes
+
+- name: Probe mlx5_ib module
+  modprobe:
+    name: mlx5_ib
+    state: present 
+  become: yes
 ...

--- a/ansible/roles/configure_ib/tasks/main.yml
+++ b/ansible/roles/configure_ib/tasks/main.yml
@@ -14,7 +14,6 @@
   - name: Parse config json
     set_fact:
       network_data: "{{ result.stdout | from_json }}"
-  - debug: var=network_data.networks[2]
   - name: Set ipaddr fact
     set_fact:
       ib_ipaddr: "{{ network_data.networks[2].ip_address }}"
@@ -24,17 +23,7 @@
   - name: Set hardware address fact
     set_fact:
       ib_hwaddr: "{{ result.stdout }}"
-  - debug: var=ib_hwaddr
   when: ib_use_config_drive | bool
-
-- debug: var=ib_ipaddr
-- name: Load kernel modules
-  modprobe:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ ib_modules }}"
-  become: yes
-  notify: Reset interface
 
 - name: Ensure kernel modules persist
   lineinfile:
@@ -44,14 +33,9 @@
     create: yes
   with_items: "{{ ib_modules }}"
   become: yes
-  notify: Reset interface
-
-- name: Copy ifcfg-ib0 network script over
-  template:
-    src: ifcfg-ib0.j2
-    dest: /etc/sysconfig/network-scripts/ifcfg-ib0
-  become: yes
-  notify: Reset interface
+  notify:
+    - Unload kernel modules
+    - Load kernel modules
 
 - name: Set selinux to permissive
   selinux:
@@ -59,6 +43,13 @@
     policy: targeted
   become: yes
   notify:
-    - Remove mlx5_ib module
-    - Probe mlx5_ib module
+    - Unload kernel modules
+    - Load kernel modules
+
+- name: Copy ifcfg-ib0 network script over
+  template:
+    src: ifcfg-ib0.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-ib0
+  become: yes
+  notify: Reset interface
 ...

--- a/ansible/roles/configure_ib/tasks/main.yml
+++ b/ansible/roles/configure_ib/tasks/main.yml
@@ -18,7 +18,6 @@
   - name: Set ipaddr fact
     set_fact:
       ib_ipaddr: "{{ network_data.networks[2].ip_address }}"
-  - debug: var=ib_ipaddr
   - name: Obtain hardware address
     command: cat /sys/class/net/ib0/address
     register: result
@@ -28,6 +27,7 @@
   - debug: var=ib_hwaddr
   when: ib_use_config_drive | bool
 
+- debug: var=ib_ipaddr
 - name: Load kernel modules
   modprobe:
     name: "{{ item }}"
@@ -52,4 +52,13 @@
     dest: /etc/sysconfig/network-scripts/ifcfg-ib0
   become: yes
   notify: Reset interface
+
+- name: Set selinux to permissive
+  selinux:
+    state: permissive
+    policy: targeted
+  become: yes
+  notify:
+    - Remove mlx5_ib module
+    - Probe mlx5_ib module
 ...


### PR DESCRIPTION
This PR fixes the following traceback we were seeing during boot which prevented the mlx5_ib module from reloading correctly:

```
[   13.035693] mlx5_ib: Mellanox Connect-IB Infiniband driver v5.0-0
[   13.062630] mlx5_0:modify_to_rts:288:(pid 1285): could not change QP131 state to INIT: -13
[   13.072806] WARNING: CPU: 39 PID: 1285 at drivers/infiniband/hw/mlx5/gsi.c:362 setup_qp+0x175/0x220 [mlx5_ib]
[   13.084803] Modules linked in: mlx5_ib(+) ib_core xfs libcrc32c mlx5_core ixgbe igb crct10dif_pclmul mlxfw crc32_pclmul i2c_algo_bit crc32c_intel devlink dca ghash_clmulni_inteli
[   13.109560] CPU: 39 PID: 1285 Comm: systemd-modules Not tainted 4.16.12-200.fc27.x86_64 #1
[   13.109561] Hardware name: Dell Inc. PowerEdge R630/02C2CP, BIOS 2.6.0 10/26/2017
[   13.109568] RIP: 0010:setup_qp+0x175/0x220 [mlx5_ib]
[   13.109571] RSP: 0018:ffffa750c8007990 EFLAGS: 00010286
[   13.134988] RAX: 00000000fffffff3 RBX: ffff9b07b52fd800 RCX: 0000000000000000
[   13.134989] RDX: 0000000000000000 RSI: ffff9b07bf2d6938 RDI: ffff9b07bf2d6938
[   13.134990] RBP: 0000000000000000 R08: 0000000000000594 R09: 0000000000000007
[   13.134991] R10: ffffd04c40e77500 R11: ffffffff929691ed R12: ffff9b07b2188000
[   13.134994] R13: ffff9b07b9044c00 R14: ffff9b07b52fd97c R15: 0000000000000000
[   13.183623] FS:  00007f99e4413100(0000) GS:ffff9b07bf2c0000(0000) knlGS:0000000000000000
[   13.183625] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[   13.183625] CR2: 00005606ca628000 CR3: 0000002030cdc002 CR4: 00000000003606e0
[   13.183627] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[   13.183628] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[   13.183628] Call Trace:
[   13.183637]  mlx5_ib_gsi_modify_qp+0xc4/0x110 [mlx5_ib]
[   13.183644]  mlx5_ib_modify_qp+0xb11/0x14f0 [mlx5_ib]
[   13.183652]  _ib_modify_qp+0x65/0x100 [ib_core]
[   13.183659]  ib_mad_init_device+0x58b/0x870 [ib_core]
[   13.183667]  ib_register_device+0x4a5/0x680 [ib_core]
[   13.183682]  ? mlx5_alloc_bfreg+0x20/0x50 [mlx5_core]
[   13.265468]  mlx5_ib_add+0xa6/0x2b0 [mlx5_ib]
[   13.265480]  mlx5_add_device+0x77/0x170 [mlx5_core]
[   13.265491]  mlx5_register_interface+0x74/0xc0 [mlx5_core]
[   13.283467]  ? 0xffffffffc01ec000
[   13.283472]  do_one_initcall+0x4e/0x18d
[   13.283476]  ? free_unref_page_commit+0x9f/0x110
[   13.283482]  ? _cond_resched+0x15/0x40
[   13.302744]  ? kmem_cache_alloc_trace+0x111/0x1c0
[   13.302748]  ? do_init_module+0x22/0x201
[   13.302749]  do_init_module+0x5b/0x201
[   13.302752]  load_module+0x259b/0x2c40
[   13.302758]  ? pick_next_task_fair+0x2f9/0x5e0
[   13.302760]  ? SYSC_init_module+0x162/0x190
[   13.302762]  ? _cond_resched+0x15/0x40
[   13.302764]  SYSC_init_module+0x162/0x190
[   13.302767]  do_syscall_64+0x74/0x180
[   13.302769]  entry_SYSCALL_64_after_hwframe+0x3d/0xa2
[   13.302771] RIP: 0033:0x7f99e3f429ba
[   13.302772] RSP: 002b:00007ffcdd6105f8 EFLAGS: 00000246 ORIG_RAX: 00000000000000af
[   13.302774] RAX: ffffffffffffffda RBX: 00005606c9daed50 RCX: 00007f99e3f429ba
[   13.302775] RDX: 00007f99e38041ad RSI: 000000000006c4c3 RDI: 00005606ca5bd360
[   13.302776] RBP: 00007f99e38041ad R08: 0000000000000000 R09: 00007ffcdd60e953
[   13.302777] R10: 0000000000000005 R11: 0000000000000246 R12: 00005606ca5bd360
[   13.302778] R13: 00005606c9daf3c0 R14: 0000000000020000 R15: 00007ffcdd610770
[   13.302779] Code: df e8 70 fc ff ff 48 3d 00 f0 ff ff 49 89 c5 77 49 89 ea 48 89 c6 48 89 df e8 18 fd ff ff 85 c0 74 10 4d 85 ed 0f 84 ed fe ff ff <0f> 0b e9 e6 fe ff ff 4c 89 f
[   13.409807] ---[ end trace dc4f3b3e5797ce9f ]---
```

Setting SELinux to permissive mode logs the following in `/var/log/audit/audit.log`:

```
type=AVC msg=audit(1552055481.658:85): avc:  denied  { access } for  pid=1570 comm="kworker/10:2" pkey=0xffff subnet_prefix=0:0:0:80fe:: scontext=system_u:system_r:systemd_modules_load_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=infiniband_pkey permissive=1
```

 Applying the policy generated using `audit2allow -a -M policy` followed by `semodule -i policy.pp` did not remedy the problem so for now, we are going to leave this in permissive mode.