### PR TITLE
Decouple openstack config from cluster setup

### DIFF
--- a/ansible/openhpc.yml
+++ b/ansible/openhpc.yml
@@ -5,6 +5,9 @@
 # Prepare cluster
 - import_playbook: setup.yml
 
+# Add openstack configuration
+- import_playbook: os-config.yml
+
 # Use mdadm to create software defined raid
 - import_playbook: mdadm.yml
 

--- a/ansible/os-config.yml
+++ b/ansible/os-config.yml
@@ -1,0 +1,36 @@
+---
+# Query OpenStack Barbican to retrieve secret keys
+# needed for a cluster deployment
+- hosts: openstack
+  gather_facts: no
+  roles:
+    - role: alaska_secrets
+      secret_name: "alaska.auth.p3-monitor"
+      secret_var: "alaska_auth_p3_monitor"
+
+# Apply generic setup configuration that is universally useful
+- hosts: cluster
+  gather_facts: no
+  become: yes
+  roles:
+    - role: stackhpc.os-config
+      monitor_secret: "{{ hostvars['localhost']['alaska_auth_p3_monitor'] }}"
+      os_config_content: |
+        ---
+        clouds:
+          {{ alaska_cloud }}:
+            auth:
+              auth_url: http://{{ controller_vip }}:5000
+              project_name: p3
+              domain_name: default
+          alaska-monasca:
+            auth:
+              auth_url: http://{{ controller_vip }}:5000
+              project_name: p3
+              domain_name: default
+              username: p3-monitor
+              password: {{ monitor_secret }}
+            region: RegionOne
+      os_config_destination: "/etc/openstack"
+      os_config_owner: root
+      os_config_group: root

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 # Sorted by maintainer name, role name
 - src: mrlesmithjr.mdadm
-- src: oasis-roles.kdump
+- src: oasis_roles.kdump
 - src: singleplatform-eng.users
 - src: stackhpc.beegfs
 - src: stackhpc.cluster-infra

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -1,15 +1,6 @@
 ---
-# Query OpenStack Barbican to retrieve secret keys
-# needed for a cluster deployment
-- hosts: openstack
-  roles:
-    - role: alaska_secrets
-      secret_name: "alaska.auth.p3-monitor"
-      secret_var: "alaska_auth_p3_monitor"
-
 # Apply generic setup configuration that is universally useful
 - hosts: cluster
-  remote_user: centos
   become: yes
   roles:
     - role: oasis_roles.kdump
@@ -18,26 +9,5 @@
       kdump_become_user: root
       kdump_crash_path: /var/crash
       kdump_core_collector_args: makedumpfile -l --message-level 1 -d 31
-      when: kdump_enable | default(true)
+      when: kdump_enable | default(false)
     - role: cluster_setup
-    - role: stackhpc.os-config
-      monitor_secret: "{{ hostvars['localhost']['alaska_auth_p3_monitor'] }}"
-      os_config_content: |
-        ---
-        clouds:
-          {{ alaska_cloud }}:
-            auth:
-              auth_url: http://{{ controller_vip }}:5000
-              project_name: p3
-              domain_name: default
-          alaska-monasca:
-            auth:
-              auth_url: http://{{ controller_vip }}:5000
-              project_name: p3
-              domain_name: default
-              username: p3-monitor
-              password: {{ monitor_secret }}
-            region: RegionOne
-      os_config_destination: "/etc/openstack"
-      os_config_owner: root
-      os_config_group: root


### PR DESCRIPTION
At the moment, OpenStack specific setup is not decoupled from generic cluster setup. This is a problem when encrypted secrets are not present in non p3-clusters. This is a problem which is addressed here.