### PR TITLE
Allow use of clouds.yaml without environment variables

### DIFF
--- a/ansible/group_vars/openstack
+++ b/ansible/group_vars/openstack
@@ -9,9 +9,9 @@ openstack_auth_type: "password"
 # compatible with the 'auth' argument of most 'os_*' Ansible modules.
 # By default we pull these from the environment of the shell executing Ansible.
 openstack_auth:
-  project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"
-  user_domain_name: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"
-  project_name: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
-  username: "{{ lookup('env', 'OS_USERNAME') }}"
-  password: "{{ lookup('env', 'OS_PASSWORD') }}"
-  auth_url: "{{ lookup('env', 'OS_AUTH_URL') }}"
+  project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') | default(omit, true) }}"
+  user_domain_name: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') | default(omit, true) }}"
+  project_name: "{{ lookup('env', 'OS_PROJECT_NAME') | default(omit, true) }}"
+  username: "{{ lookup('env', 'OS_USERNAME') | default(omit, true) }}"
+  password: "{{ lookup('env', 'OS_PASSWORD') | default(omit, true) }}"
+  auth_url: "{{ lookup('env', 'OS_AUTH_URL') | default(omit, true) }}"


### PR DESCRIPTION
Without a '| default(omit, true)' for the openstack_auth fields, the
os_stack_resources module in the os-container-infra role will fail, complaining
about a missing user domain.