### PR TITLE
Fix python-magnumclient to 2.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ shade
 openstacksdk
 python-barbicanclient
 python-keystoneclient
-python-magnumclient
+python-magnumclient==2.12.0
 python-novaclient
 python-openstackclient
 python-ironicclient


### PR DESCRIPTION
When we try to create cluster template with 2.13.0, we get this error
when interacting with rocky server:

    Unknown attribute for argument cluster_template: hidden (HTTP 400)

We ought to limit the version until this change is merged:

    https://review.opendev.org/659298