### PR TITLE
Rename ansible/{openhpc,cluster-infra-configure}.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ subdirectory.  This inventory is suffixed with the value set in
 `cluster_name`.  The cluster software can be deployed and configured
 using another playbook (for example):
 
-    ansible-playbook --vault-password-file vault-password -e @config/openhpc.yml -i ansible/inventory-openhpc ansible/openhpc.yml
+    ansible-playbook --vault-password-file vault-password -e @config/openhpc.yml -i ansible/inventory-openhpc ansible/cluster-infra-configure.yml
 
 ### Deploying and configuring Swarm SIP
 
@@ -155,5 +155,5 @@ To setup GlusterFS server:
 
 To setup hyperconverged storage and mount storage on OpenHPC node:
 
-    ansible-playbook --vault-password-file vault-password -e @config/openhpc.yml -i ansible/inventory-openhpc ansible/openhpc.yml
+    ansible-playbook --vault-password-file vault-password -e @config/openhpc.yml -i ansible/inventory-openhpc ansible/cluster-infra-configure.yml
 

--- a/ansible/cluster-infra-configure.yml
+++ b/ansible/cluster-infra-configure.yml
@@ -22,7 +22,6 @@
 # - glusterfs
 # - beegfs
 # - <undefined>
-#
 - import_playbook: '{{ cluster_fs }}.yml'
   when: cluster_fs is defined
 

--- a/tests/test-openhpc.sh
+++ b/tests/test-openhpc.sh
@@ -48,5 +48,5 @@ if [[ $STATE != absent ]]; then
     -e @config/openhpc.yml \
     -e @config/test-openhpc.yml \
     -i ansible/inventory-test-openhpc \
-    ansible/openhpc.yml
+    ansible/cluster-infra-configure.yml
 fi


### PR DESCRIPTION
We have been using `ansible/openhpc.yml` to configure all types of clusters (Beegfs, Gluster, OpenHPC, GPU, Kata, etc.), not just OpenHPC clusters. It is slightly misleading to be calling this playbook `openhpc.yml` which gives the impression it is only for creating OpenHPC clusters. With the right combination of cluster roles and boolean toggles, it has quite a generic use case hence a more generic name of `cluster-infra-configure.yml` seems more suitable following the same pattern used by `container-infra-configure.yml` for clusters created using Magnum.