### PR TITLE
Add toggle for configure_ib

### DIFF
--- a/ansible/cluster-infra-configure.yml
+++ b/ansible/cluster-infra-configure.yml
@@ -2,6 +2,9 @@
 # Prepare cluster
 - import_playbook: setup.yml
 
+- import_playbook: configure-ib.yml
+  when: configure_ib_enabled | default(false) | bool
+
 # Prepare cluster
 - import_playbook: latest-packages.yml
 

--- a/config/gpu.yml
+++ b/config/gpu.yml
@@ -19,6 +19,10 @@ cluster_nodenet_resource: "Cluster::NodeNet3"
 # Enable the use of config drive, for managing IP assignment on IPoIB
 cluster_config_drive: true
 
+# GPU images do not have infiniband packages built in so run this
+# playbook to ensure it is enabled.
+configure_ib_enabled: true
+
 # The cluster consists of a single compute group.
 cluster_groups:
   - "{{ compute }}"


### PR DESCRIPTION
Some images do not have Infiniband drivers preinstalled which means that
this role is required to run in order to install the drivers and enable
the interface.