### PR TITLE
Add a cluster_runtime role for slurm clusters

### DIFF
--- a/ansible/slurm.yml
+++ b/ansible/slurm.yml
@@ -3,13 +3,14 @@
   - cluster_login
   - cluster_control
   - cluster_batch
+  - cluster_runtime
   become: yes
   roles:
     - role: stackhpc.openhpc
       openhpc_cluster_name: "{{ cluster_name }}"
       openhpc_slurm_control_host: "{{ groups['cluster_control'] | first }}"
       openhpc_enable:
-        control: "{{ inventory_hostname in groups['cluster_control'] }}"
-        batch: "{{ inventory_hostname in groups['cluster_batch'] }}"
-        runtime: true
+        control: "{{ inventory_hostname in groups['cluster_control'] | default([]) }}"
+        batch: "{{ inventory_hostname in groups['cluster_batch'] | default([]) }}"
+        runtime: "{{ inventory_hostname in groups['cluster_runtime'] | default([]) }}"
 ...

--- a/config/openhpc.yml
+++ b/config/openhpc.yml
@@ -65,6 +65,8 @@ cluster_roles:
     groups: [ "{{ slurm_login }}" ]
   - name: "batch"
     groups: [ "{{ slurm_compute }}" ]
+  - name: "runtime"
+    groups: "{{ cluster_groups }}"
   - name: "mdadm"
     groups: [ "{{ slurm_compute }}" ]
   - name: "glusterfs_server"


### PR DESCRIPTION
Sometimes, we may want to allow users to login to a cluster (e.g. the
gpu cluster) without slurm capability, in which case it makes sense to
have cluster_runtime as a separate role to cluster_login.