### PR TITLE
Fix reset interface handler

### DIFF
--- a/ansible/roles/configure_ib/handlers/main.yml
+++ b/ansible/roles/configure_ib/handlers/main.yml
@@ -7,6 +7,6 @@
   become: true
 
 - name: Reset interface
-  include: reset_interface.yml
+  import_tasks: reset_interface.yml
   become: true
 ...

--- a/ansible/roles/configure_ib/tasks/reset_interface.yml
+++ b/ansible/roles/configure_ib/tasks/reset_interface.yml
@@ -1,6 +1,8 @@
 ---
 - name: Bring interface down
   shell: ifdown ib0
+  register: result
+  failed_when: "result.rc != 0 and 'is not an active connection' not in result.stderr"
 - name: Unload kernel modules
   modprobe:
     name: "{{ item }}"


### PR DESCRIPTION
Before this change, I was seeing:

ERROR! The requested handler 'Reset interface' was not found in either the main handlers list nor in the listening handlers list

This fixes #94