### PR TITLE
Add packages

### DIFF
--- a/config/openhpc.yml
+++ b/config/openhpc.yml
@@ -156,6 +156,7 @@ mdadm_arrays:
 # A list of OpenHPC runtime libraries to install on compute and control nodes
 openhpc_packages:
   - openmpi-gnu-ohpc
+  - ohpc-gnu8-perf-tools
   - cfitsio
   - cfitsio-devel
   - wcslib

--- a/config/openhpc.yml
+++ b/config/openhpc.yml
@@ -179,4 +179,6 @@ extra_packages:
   - htop
   - screen
   - tmux
+  - cmake
+  - jq
 ...


### PR DESCRIPTION
This adds the gnu8 compilers (currently only got gnu5 and gnu7) plus associated mpi libraries and performance packages.

It also adds `cmake` (required for some builds) and `jq` to help parse json from the command-line.

All supports benchmarking work.