### PR TITLE
Fix openstacksdk and python-ironicclient at last py2 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 ansible>=2.9.0
 os-client-config
 shade
-openstacksdk==0.45.0; python_version<='2.7'
+openstacksdk==0.40.0; python_version<='2.7'
 python-barbicanclient
 python-keystoneclient
 python-magnumclient>=2.12.0
 python-novaclient
 python-openstackclient
-python-ironicclient
+python-ironicclient==3.1.2; python_version<='2.7'
 python-heatclient


### PR DESCRIPTION
Changes give the last supported versions for python 2. See:

- https://docs.openstack.org/releasenotes/openstacksdk/ussuri.html#bug-fixes
- https://docs.openstack.org/releasenotes/python-ironicclient/ussuri.html#relnotes-4-0-0-stable-ussuri-upgrade-notes

Both of these were giving problems on dev-director during openhpc rebuild.